### PR TITLE
Add auto-hide options and other fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
           "type": "string",
           "description": "The path to the lazygit executable",
           "scope": "machine"
+        },
+        "lazygit-vscode.autoHideSideBar": {
+          "type": "boolean",
+          "description": "Auto-hide the side bar when showing lazygit",
+          "scope": "window"
+        },
+        "lazygit-vscode.autoHidePanel": {
+          "type": "boolean",
+          "description": "Auto-hide the panel when showing lazygit",
+          "scope": "window"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,17 @@
         "key": "ctrl+shift+l",
         "mac": "cmd+shift+l"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Lazygit",
+      "properties": {
+        "lazygit-vscode.lazygitPath": {
+          "type": "string",
+          "description": "The path to the lazygit executable",
+          "scope": "machine"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,23 +4,19 @@ import * as os from "os";
 import { exec } from "child_process";
 
 let lazyGitTerminal: vscode.Terminal | undefined;
-let isLazyGitVisible = false;
 
 export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
     "lazygit-vscode.toggle",
     async () => {
       if (lazyGitTerminal) {
-        if (isLazyGitVisible) {
+        if (isLazyGitVisible()) {
           await hideWindow();
-          isLazyGitVisible = false;
         } else {
           showAndFocusTerminal(lazyGitTerminal);
-          isLazyGitVisible = true;
         }
       } else {
         await createWindow();
-        isLazyGitVisible = true;
       }
     }
   );
@@ -40,10 +36,17 @@ async function hideWindow() {
   if (openTabs == 1 && lazyGitTerminal) {
     lazyGitTerminal.dispose();
     lazyGitTerminal = undefined;
-    isLazyGitVisible = false;
   } else {
     await vscode.commands.executeCommand("workbench.action.previousEditor");
   }
+}
+
+function isLazyGitVisible() {
+  return (
+    lazyGitTerminal &&
+    vscode.window?.activeTerminal === lazyGitTerminal &&
+    vscode.window?.activeTextEditor === undefined
+  );
 }
 
 function findLazyGitOnPath(): Promise<string> {
@@ -96,7 +99,6 @@ async function createWindow() {
   vscode.window.onDidCloseTerminal((terminal) => {
     if (terminal === lazyGitTerminal) {
       lazyGitTerminal = undefined;
-      isLazyGitVisible = false;
     }
   });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,9 +13,11 @@ export function activate(context: vscode.ExtensionContext) {
         if (isLazyGitVisible()) {
           await hideWindow();
         } else {
+          await onShown();
           showAndFocusTerminal(lazyGitTerminal);
         }
       } else {
+        await onShown();
         await createWindow();
       }
     }
@@ -38,6 +40,16 @@ async function hideWindow() {
     lazyGitTerminal = undefined;
   } else {
     await vscode.commands.executeCommand("workbench.action.previousEditor");
+  }
+}
+
+async function onShown() {
+  const config = vscode.workspace.getConfiguration("lazygit-vscode");
+  if (config.get<boolean>("autoHideSideBar")) {
+    await vscode.commands.executeCommand("workbench.action.closeSidebar");
+  }
+  if (config.get<boolean>("autoHidePanel")) {
+    await vscode.commands.executeCommand("workbench.action.closePanel");
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,96 +1,104 @@
-import * as vscode from 'vscode';
-import * as fs from 'fs';
-import * as os from 'os';
-import { exec } from 'child_process';
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as os from "os";
+import { exec } from "child_process";
 
 let lazyGitTerminal: vscode.Terminal | undefined;
 let isLazyGitVisible = false;
 
 export function activate(context: vscode.ExtensionContext) {
-
-    let disposable = vscode.commands.registerCommand('lazygit-vscode.toggle', async () => {
-
-        if (lazyGitTerminal) {
-            if (isLazyGitVisible) {
-                await hideWindow();
-                isLazyGitVisible = false;
-            } else {
-                showAndFocusTerminal(lazyGitTerminal);
-                isLazyGitVisible = true;
-            }
+  let disposable = vscode.commands.registerCommand(
+    "lazygit-vscode.toggle",
+    async () => {
+      if (lazyGitTerminal) {
+        if (isLazyGitVisible) {
+          await hideWindow();
+          isLazyGitVisible = false;
         } else {
-            await createWindow();
-            isLazyGitVisible = true;
+          showAndFocusTerminal(lazyGitTerminal);
+          isLazyGitVisible = true;
         }
-    });
+      } else {
+        await createWindow();
+        isLazyGitVisible = true;
+      }
+    }
+  );
 
-    context.subscriptions.push(disposable);
+  context.subscriptions.push(disposable);
 }
 
 function showAndFocusTerminal(terminal: vscode.Terminal) {
-    terminal.show(true);
-    vscode.commands.executeCommand('workbench.action.terminal.focus');
+  terminal.show(true);
+  vscode.commands.executeCommand("workbench.action.terminal.focus");
 }
 
 async function hideWindow() {
-    const openTabs = vscode.window.tabGroups.all.flatMap(group => group.tabs).length;
-    if (openTabs == 1 && lazyGitTerminal) {
-        lazyGitTerminal.dispose();
-        lazyGitTerminal = undefined;
-        isLazyGitVisible = false;
-    } else {
-        await vscode.commands.executeCommand('workbench.action.previousEditor');
-    }
+  const openTabs = vscode.window.tabGroups.all.flatMap(
+    (group) => group.tabs
+  ).length;
+  if (openTabs == 1 && lazyGitTerminal) {
+    lazyGitTerminal.dispose();
+    lazyGitTerminal = undefined;
+    isLazyGitVisible = false;
+  } else {
+    await vscode.commands.executeCommand("workbench.action.previousEditor");
+  }
 }
 
 function findLazyGitOnPath(): Promise<string> {
-    return new Promise((resolve, reject) => {
-        const command = process.platform === 'win32' ? 'where lazygit' : 'which lazygit';
-        exec(command, (error, stdout) => {
-            if (error) reject(new Error('LazyGit not found on PATH'));
-            else resolve(stdout.trim());
-        });
+  return new Promise((resolve, reject) => {
+    const command =
+      process.platform === "win32" ? "where lazygit" : "which lazygit";
+    exec(command, (error, stdout) => {
+      if (error) reject(new Error("LazyGit not found on PATH"));
+      else resolve(stdout.trim());
     });
+  });
 }
 
 async function createWindow() {
-    let workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-    if (!workspaceFolder) workspaceFolder = os.homedir();
+  let workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+  if (!workspaceFolder) workspaceFolder = os.homedir();
 
-    const config = vscode.workspace.getConfiguration('lazygit-vscode');
-    let lazyGitPath = config.get<string>('lazygitPath');
-    if (!lazyGitPath) {
-        try {
-            lazyGitPath = await findLazyGitOnPath();
-        } catch (error) {
-            vscode.window.showErrorMessage('LazyGit not found in config or on PATH. Please check your settings.');
-            return;
-        }
+  const config = vscode.workspace.getConfiguration("lazygit-vscode");
+  let lazyGitPath = config.get<string>("lazygitPath");
+  if (!lazyGitPath) {
+    try {
+      lazyGitPath = await findLazyGitOnPath();
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        "LazyGit not found in config or on PATH. Please check your settings."
+      );
+      return;
     }
+  }
 
-    if (!fs.existsSync(lazyGitPath)) {
-        vscode.window.showErrorMessage(`LazyGit not found at ${lazyGitPath}. Please check your settings.`);
-        return;
+  if (!fs.existsSync(lazyGitPath)) {
+    vscode.window.showErrorMessage(
+      `LazyGit not found at ${lazyGitPath}. Please check your settings.`
+    );
+    return;
+  }
+
+  lazyGitTerminal = vscode.window.createTerminal({
+    name: "LazyGit",
+    cwd: workspaceFolder,
+    shellPath: process.platform === "win32" ? "cmd.exe" : "/bin/bash",
+    shellArgs:
+      process.platform === "win32" ? ["/c", lazyGitPath] : ["-c", lazyGitPath],
+    location: vscode.TerminalLocation.Editor,
+  });
+
+  showAndFocusTerminal(lazyGitTerminal);
+
+  // Monitor the terminal for closure
+  vscode.window.onDidCloseTerminal((terminal) => {
+    if (terminal === lazyGitTerminal) {
+      lazyGitTerminal = undefined;
+      isLazyGitVisible = false;
     }
-
-    lazyGitTerminal = vscode.window.createTerminal({
-        name: "LazyGit",
-        cwd: workspaceFolder,
-        shellPath: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
-        shellArgs: process.platform === 'win32' ? ['/c', lazyGitPath] : ['-c', lazyGitPath],
-        location: vscode.TerminalLocation.Editor
-    });
-
-    showAndFocusTerminal(lazyGitTerminal);
-
-    // Monitor the terminal for closure
-    vscode.window.onDidCloseTerminal(terminal => {
-        if (terminal === lazyGitTerminal) {
-            lazyGitTerminal = undefined;
-            isLazyGitVisible = false;
-        }
-    });
+  });
 }
 
-export function deactivate() {
-}
+export function deactivate() {}


### PR DESCRIPTION
- Add config options to auto-hide the panel and the side bar when activating lazygit
  - Useful if you have a small screen and prefer lazygit to take up all the available space
  - Ideally it would remember the visibility of the side bar and panel and restore it when lazygit is hidden, but I couldn't figure out how to do that...
- Make the `lazygitPath` config show up in the settings view
- Make showing/hiding the lazygit tab a little more reliable (hopefully)