### PR TITLE
Add configs for auto-hiding side bar and panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Use the keyboard shortcut `Ctrl+Shift+L` (or `Cmd+Shift+L` on macOS) to toggle L
 ## Extension Settings
 
 - `lazygit-vscode.lazygitPath`: Manually set LazyGit path. Otherwise use default system PATH.
+- `lazygit-vscode.autoHideSideBar`: Auto-hide the side bar when showing lazygit.
+- `lazygit-vscode.autoHidePanel`: Auto-hide the panel when showing lazygit.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
           "type": "string",
           "description": "The path to the lazygit executable",
           "scope": "machine"
+        },
+        "lazygit-vscode.autoHideSideBar": {
+          "type": "boolean",
+          "description": "Auto-hide the side bar when showing lazygit",
+          "scope": "window"
+        },
+        "lazygit-vscode.autoHidePanel": {
+          "type": "boolean",
+          "description": "Auto-hide the panel when showing lazygit",
+          "scope": "window"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,9 +13,11 @@ export function activate(context: vscode.ExtensionContext) {
         if (terminalFocused(lazyGitTerminal)) {
           hideTerminal(lazyGitTerminal);
         } else {
+          await onShown();
           showAndFocusTerminal(lazyGitTerminal);
         }
       } else {
+        await onShown();
         await createWindow();
       }
     }
@@ -48,6 +50,16 @@ function hideTerminal(terminal: vscode.Terminal) {
     vscode.commands.executeCommand(
       "workbench.action.openPreviousRecentlyUsedEditor"
     );
+  }
+}
+
+async function onShown() {
+  const config = vscode.workspace.getConfiguration("lazygit-vscode");
+  if (config.get<boolean>("autoHideSideBar")) {
+    await vscode.commands.executeCommand("workbench.action.closeSidebar");
+  }
+  if (config.get<boolean>("autoHidePanel")) {
+    await vscode.commands.executeCommand("workbench.action.closePanel");
   }
 }
 


### PR DESCRIPTION
Add config options to auto-hide the panel and the side bar when activating lazygit
- Useful if you have a small screen and prefer lazygit to take up all the available space
- Ideally it would remember the visibility of the side bar and panel and restore it when lazygit is hidden, but I couldn't figure out how to do that.