### PR TITLE
Use `powershell.exe` instead of `cmd.exe` to launch Lazygit on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,7 +138,7 @@ async function createWindow() {
     cwd: workspaceFolder,
     shellPath:
       process.platform === "win32"
-        ? "cmd.exe"
+        ? "powershell.exe"
         : await findExecutableOnPath("bash"),
     shellArgs:
       process.platform === "win32"


### PR DESCRIPTION
Fixes #10