### PR TITLE
feat: allow setting to always restore preferred UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,17 +45,35 @@
         "lazygit-vscode.autoHideSideBar": {
           "type": "boolean",
           "description": "Auto-hide the side bar when showing lazygit",
-          "scope": "window"
+          "scope": "window",
+          "default": false
         },
         "lazygit-vscode.autoHidePanel": {
           "type": "boolean",
           "description": "Auto-hide the panel when showing lazygit",
-          "scope": "window"
+          "scope": "window",
+          "default": false
         },
         "lazygit-vscode.autoMaximizeWindow": {
           "type": "boolean",
           "description": "Fullscreen the lazygit window, hiding any splits (this also minimizes sidebar)",
-          "scope": "window"
+          "scope": "window",
+          "default": false
+        },
+        "lazygit-vscode.autoRestoreSideBar": {
+          "type": "boolean",
+          "default": false,
+          "description": "Restore sidebar when quitting LazyGit"
+        },
+        "lazygit-vscode.autoRestoreSecondarySideBar": {
+          "type": "boolean",
+          "default": false,
+          "description": "Restore secondary sidebar when quitting LazyGit"
+        },
+        "lazygit-vscode.autoRestorePanel": {
+          "type": "boolean",
+          "default": false,
+          "description": "Restore the panel when quitting LazyGit"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,12 @@
         },
         "lazygit-vscode.autoMaximizeWindow": {
           "type": "boolean",
-          "description": "Fullscreen the lazygit window, hiding any splits (this also minimizes sidebar)",
+          "description": "Fullscreen the lazygit window, hiding any splits (see also autoMaximizeWindowKeepSidebarOpen)",
+          "scope": "window"
+        },
+        "lazygit-vscode.autoMaximizeWindowKeepSidebarOpen": {
+          "type": "boolean",
+          "description": "Sidebar will be open when the lazygit window is maximized",
           "scope": "window",
           "default": false
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ interface LazyGitConfig {
   autoRestoreSideBar: boolean;
   autoRestoreSecondarySideBar: boolean;
   autoRestorePanel: boolean;
+  autoMaximizeWindowKeepSidebarOpen: boolean;
 }
 
 function loadConfig(): LazyGitConfig {
@@ -34,6 +35,10 @@ function loadConfig(): LazyGitConfig {
     autoRestoreSideBar: config.get<boolean>("autoRestoreSideBar", true),
     autoRestoreSecondarySideBar: config.get<boolean>("autoRestoreSecondarySideBar", true),
     autoRestorePanel: config.get<boolean>("autoRestorePanel", true),
+    autoMaximizeWindowKeepSidebarOpen: config.get<boolean>(
+      "autoMaximizeWindowKeepSidebarOpen",
+      false
+    ),
   };
 }
 
@@ -47,7 +52,7 @@ async function reloadIfConfigChange() {
 function expandPath(pth: string): string {
   pth = pth.replace(/^~(?=$|\/|\\)/, os.homedir());
   if (process.platform === "win32") {
-    pth = pth.replace(/%([^%]+)%/g, (_,n) => process.env[n] || "");
+    pth = pth.replace(/%([^%]+)%/g, (_, n) => process.env[n] || "");
   } else {
     pth = pth.replace(/\$([A-Za-z0-9_]+)/g, (_, n) => process.env[n] || "");
   }
@@ -204,6 +209,11 @@ function onShown() {
     vscode.commands.executeCommand(
       "workbench.action.maximizeEditorHideSidebar"
     );
+    if (globalConfig.autoMaximizeWindowKeepSidebarOpen) {
+      vscode.commands.executeCommand(
+        "workbench.action.toggleSidebarVisibility"
+      );
+    }
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(disposable);
 }
 
-export function deactivate() {}
+export function deactivate() { }
 
 /* ---  Window --- */
 
@@ -219,8 +219,8 @@ function onShown() {
 
 function onHide() {
   // Restore sidebar if it was configured to be auto-hidden
-  if (globalConfig.autoHideSideBar && globalConfig.autoRestoreSideBar) {
-    vscode.commands.executeCommand("workbench.view.explorer");
+  if (globalConfig.autoHideSideBar && globalConfig.autoRestoreSideBar && !globalConfig.autoMaximizeWindowKeepSidebarOpen) {
+    vscode.commands.executeCommand("workbench.action.toggleSidebarVisibility");
   }
 
   // Restore secondary sidebar if it was configured to be auto-hidden

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,9 @@ interface LazyGitConfig {
   autoHideSideBar: boolean;
   autoHidePanel: boolean;
   autoMaximizeWindow: boolean;
+  autoRestoreSideBar: boolean;
+  autoRestoreSecondarySideBar: boolean;
+  autoRestorePanel: boolean;
 }
 
 function loadConfig(): LazyGitConfig {
@@ -28,6 +31,9 @@ function loadConfig(): LazyGitConfig {
     autoHideSideBar: config.get<boolean>("autoHideSideBar", false),
     autoHidePanel: config.get<boolean>("autoHidePanel", false),
     autoMaximizeWindow: config.get<boolean>("autoMaximizeWindow", false),
+    autoRestoreSideBar: config.get<boolean>("autoRestoreSideBar", true),
+    autoRestoreSecondarySideBar: config.get<boolean>("autoRestoreSecondarySideBar", true),
+    autoRestorePanel: config.get<boolean>("autoRestorePanel", true),
   };
 }
 
@@ -154,8 +160,8 @@ async function createWindow() {
   vscode.window.onDidCloseTerminal((terminal) => {
     if (terminal === lazyGitTerminal) {
       lazyGitTerminal = undefined;
-      vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
       onHide();
+      restoreEditor();
     }
   });
 }
@@ -202,9 +208,32 @@ function onShown() {
 }
 
 function onHide() {
+  // Restore sidebar if it was configured to be auto-hidden
+  if (globalConfig.autoHideSideBar && globalConfig.autoRestoreSideBar) {
+    vscode.commands.executeCommand("workbench.view.explorer");
+  }
+
+  // Restore secondary sidebar if it was configured to be auto-hidden
+  if (globalConfig.autoHideSideBar && globalConfig.autoRestoreSecondarySideBar) {
+    vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar");
+  }
+
+  // Restore panel if it was configured to be auto-hidden
+  if (globalConfig.autoHidePanel && globalConfig.autoRestorePanel) {
+    vscode.commands.executeCommand("workbench.action.togglePanel");
+  }
+
   if (globalConfig.autoMaximizeWindow) {
     vscode.commands.executeCommand("workbench.action.evenEditorWidths");
   }
+}
+
+function restoreEditor() {
+  const timeoutValue = globalConfig.autoRestorePanel ? 100 : 0;
+
+  setTimeout(() => {
+    vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
+  }, timeoutValue);
 }
 
 /* --- Utils --- */


### PR DESCRIPTION
If someone usually works with the sidebar, or the secondarySidebar, or panel open, this gives them the ability to restore those UI elements when LazyGit closes. 

It's not based on the last open/closed status of any of these components, because I guess VSCode doesn't have an API for that, unfortunately. But, still...I think this is better than nothing! For example, I always have the fileExplorer open unless I manually close it for some reason, so restoring _at least_ that will be how I use these settings. And I made them all configurable for maximum user preference flexibility. 