### PR TITLE
PR For adding context to lazygit window

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import assert = require("assert");
 let lazyGitTerminal: vscode.Terminal | undefined;
 let globalConfig: LazyGitConfig;
 let globalConfigJSON: string;
+const LAZYGIT_CONTEXT_KEY = "lazygitFocus";
 
 /* --- Config --- */
 
@@ -206,6 +207,7 @@ function closeWindow() {
 }
 
 function onShown() {
+  vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, true);
   const shouldKeep = (behavior: PanelBehavior) => behavior === "keep";
   const shouldHide = (behavior: PanelBehavior) =>
     behavior === "hide" || behavior === "hideRestore";
@@ -247,6 +249,7 @@ function onShown() {
 }
 
 function onHide() {
+  vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, false);
   // Restore panels
   const shouldRestore = (behavior: PanelBehavior) => behavior === "hideRestore";
 


### PR DESCRIPTION
I've introduced a new context key lazygitFocus:
Defined the constant at the top of the file.
Set the context to true inside onShown() when the LazyGit window is active.
Reset the context to false inside onHide() when the window is hidden or closed.
You can now reference when: lazygitFocus (or combine with other clauses like terminalFocus) in keybindings.

Hope you can accept this 🙏