### PR TITLE
Lazygit focus context

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lazygit-vscode",
   "displayName": "LazyGit VSCode",
   "description": "Native integration of LazyGit directly in a VSCode window",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "publisher": "TomPollak",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import assert = require("assert");
 let lazyGitTerminal: vscode.Terminal | undefined;
 let globalConfig: LazyGitConfig;
 let globalConfigJSON: string;
+const LAZYGIT_CONTEXT_KEY = "lazygitFocus";
 
 /* --- Config --- */
 
@@ -206,6 +207,7 @@ function closeWindow() {
 }
 
 function onShown() {
+  vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, true);
   const shouldKeep = (behavior: PanelBehavior) => behavior === "keep";
   const shouldHide = (behavior: PanelBehavior) =>
     behavior === "hide" || behavior === "hideRestore";
@@ -247,6 +249,7 @@ function onShown() {
 }
 
 function onHide() {
+  vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, false);
   // Restore panels
   const shouldRestore = (behavior: PanelBehavior) => behavior === "hideRestore";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,15 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  context.subscriptions.push(disposable);
+  const updateLazyGitFocusContext = () => {
+    vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, windowFocused());
+  };
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(updateLazyGitFocusContext),
+    vscode.window.onDidChangeActiveTerminal(updateLazyGitFocusContext),
+    disposable
+  );
 }
 
 export function deactivate() {}
@@ -207,7 +215,6 @@ function closeWindow() {
 }
 
 function onShown() {
-  vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, true);
   const shouldKeep = (behavior: PanelBehavior) => behavior === "keep";
   const shouldHide = (behavior: PanelBehavior) =>
     behavior === "hide" || behavior === "hideRestore";
@@ -249,7 +256,6 @@ function onShown() {
 }
 
 function onHide() {
-  vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, false);
   // Restore panels
   const shouldRestore = (behavior: PanelBehavior) => behavior === "hideRestore";
 


### PR DESCRIPTION
Changed to trigger context on active window changes

- if trying to trigger manually in onShown and onHide, this will miss if
the user changes window manually (aka by clicking tab or quick switcher)