### PR TITLE
Support for multi-root workspaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -315,8 +315,14 @@ function expandPath(pth: string): string {
 function getWorkspaceFolder(): string {
   const activeDocumentUri = vscode.window.activeTextEditor?.document.uri;
   let workspaceFolder: vscode.WorkspaceFolder | undefined;
-  if (activeDocumentUri) workspaceFolder = vscode.workspace.getWorkspaceFolder(activeDocumentUri);
-  workspaceFolder ??= vscode.workspace.workspaceFolders?.[0];
+
+  if (activeDocumentUri) {
+    workspaceFolder = vscode.workspace.getWorkspaceFolder(activeDocumentUri);
+  }
+
+  if (!workspaceFolder) {
+    workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  }
 
   return workspaceFolder?.uri.fsPath ?? os.homedir();
 }


### PR DESCRIPTION
Currently, when working with multiple project folders opened in a single vscode window ([multi-root workspace](https://code.visualstudio.com/docs/editing/workspaces/multi-root-workspaces)), the extension always executes lazygit command with working directory set to the first project workspace root, with no way of opening lazygit for other workspaces.

Proposed change tries to address that by checking currently opened document uri and matching it with window workspaces, falling back to the current logic (first workspace/os homedir) when no document is opened or when document doesn't match any workspace root.


While testing, I've noticed a single potentially unwanted behaviour - since we keep the reference to the opened lazygit terminal window, in a scenario where we open lazygit for workspace X, then open a document from workspace Y without closing the lazygit window, command will focus already opened lazygit window for "incorrect" workspace, instead of opening second window with lazygit for the active workspace.

This could be further improved but I think it may be a pretty opinionated behaviour and changing it will require some pretty heavier modifications to the code (we would need to keep track of all opened windows with their working directories) - that's why I didn't want to make that change without your opinion.

Thanks for the extension, works really nicely!

