### PR TITLE
fix(path): avoid crashing when workspace path contains spaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,7 +137,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 }
 
-export function deactivate() {}
+export function deactivate() { }
 
 /* ---  Window --- */
 
@@ -172,8 +172,8 @@ async function createWindow() {
   const shellArgs = activateEnvironment
     ? []
     : process.platform === "win32"
-    ? ["/c", lazyGitCommand]
-    : ["-c", lazyGitCommand];
+      ? ["/c", lazyGitCommand]
+      : ["-c", lazyGitCommand];
 
   lazyGitTerminal = vscode.window.createTerminal({
     name: "LazyGit",
@@ -301,7 +301,7 @@ function onHide() {
   // Editor Focus -- panel / auxiliaryBar will take focus so short delay required
   const timeoutValue =
     globalConfig.panels.panel === "hideRestore" ||
-    globalConfig.panels.secondarySidebar === "hideRestore"
+      globalConfig.panels.secondarySidebar === "hideRestore"
       ? 200
       : 0;
   setTimeout(() => {
@@ -317,7 +317,7 @@ function findExecutableOnPath(executable: string): Promise<string> {
     const command =
       process.platform === "win32"
         ? `where ${executable}`
-        : `cd ${workspaceFolder} && which ${executable}`;
+        : `cd "${workspaceFolder}" && which ${executable}`;
     exec(command, (error, stdout) => {
       if (error) reject(new Error(`${executable} not found on PATH`));
       else resolve(stdout.trim());


### PR DESCRIPTION
Hi, thank you for your extension. I just noticed that it crashes when I try to launch it on a workspace that contains spaces. 
This little patch should fix it :)

