### PR TITLE
Optional Lazygit editor auto-configuration and keybinding replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,18 @@ https://github.com/tom-pollak/lazygit-vscode/assets/26611948/5924db82-7937-4ed9-
 
 ## VSCode integration
 
-Set the following in your [LazyGit config](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md) for VSCode support:
+### Automatic Configuration
+
+The extension can automatically configure Lazygit specifically when it's run from within VS Code, without affecting your normal LazyGit config files. This extra config includes:
+
+- Making Lazygit use VS Code (or its fork) as its editor (`e` keybinding), enabled by default
+- Adding a keybinding of your choice (e.g. `q`) to hide Lazygit and overriding the existing `quit` keybinding (e.g. `Q`)
+
+For more details, please refer to the [Extension Settings](#extension-settings) section below.
+
+### Manual Configuration
+
+If you prefer manual configuration, you can set `lazygit-vscode.autoConfigLazygitEditor` to `"off"` and set the following in your [LazyGit config](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md) for VS Code support:
 
 ```yaml
 os:
@@ -77,6 +88,29 @@ Use the keyboard shortcut `Ctrl+Shift+L` (or `Cmd+Shift+L` on macOS) to toggle L
 - `lazygit-vscode.configPath`: Set custom LazyGit config. Useful if you like different behaviour between VSCode and CLI.
 - `lazygit-vscode.autoMaximizeWindow`: Maximize the lazygit window in the editor (keeps sidebar visible). Useful when working with split editors.
 - `lazygit-vscode.venvActivationDelay`: Delay in milliseconds to wait for Python virtual environment activation before launching lazygit (default: 100). Increase this value if your Python environment takes longer to activate.
+
+### Automatic Editor Configuration
+
+- `lazygit-vscode.autoConfigLazygitEditor`: Automatically configure Lazygit to use VS Code as its editor (only when run from within VS Code). This is enabled by default. Available options:
+  - `"off"`: Disable automatic Lazygit editor configuration.
+  - `"cli"`: Use VS Code's CLI interface to open files for editing (default).
+  - `"urlScheme"`: Use VS Code's URL scheme to open files for editing. Can be much faster, at least on some platforms (e.g., macOS).
+
+### Lazygit Keybindings
+
+- `lazygit-vscode.lazygitKeybindings`: Custom keybindings to apply when running Lazygit from within VS Code. None are set by default. Available options:
+  - `"toggle"`: Toggle the visibility of the Lazygit panel. Since this action is triggered when the panel is focused, it effectively hides it.
+  - `"quit"`: Quit Lazygit.
+
+Example:
+```json
+"lazygit-vscode.lazygitKeybindings": {
+  "toggle": "q",
+  "quit": "Q"
+}
+```
+
+This rebinds the `q` key to hide Lazygit (instead of quitting it), and `Q` to quit it. Makes it a joy to use with Vim-style keybindings while saving some startup/teardown time and preserving Lazygit UI state.
 
 ### Panel Behavior
 

--- a/package.json
+++ b/package.json
@@ -99,11 +99,42 @@
           "scope": "window",
           "default": false
         },
+        "lazygit-vscode.lazygitKeybindings": {
+          "type": "object",
+          "description": "Custom Lazygit keybindings to apply when running inside VS Code. For example, map 'q' to 'toggle' (hide) Lazygit, and 'Q' to quit.",
+          "properties": {
+            "toggle": {
+              "type": "string",
+              "description": "Keybinding to toggle (essentially meaning hide) Lazygit (e.g., 'q')",
+              "default": ""
+            },
+            "quit": {
+              "type": "string",
+              "description": "Keybinding to quit Lazygit (e.g., 'Q')",
+              "default": ""
+            }
+          }
+        },
         "lazygit-vscode.venvActivationDelay": {
           "type": "number",
           "description": "Delay in milliseconds to wait for Python virtual environment activation before launching lazygit",
           "scope": "window",
           "default": 200
+        },
+        "lazygit-vscode.autoConfigLazygitEditor": {
+          "type": "string",
+          "enum": [
+            "off",
+            "cli",
+            "urlScheme"
+          ],
+          "default": "cli",
+          "description": "Makes lazygit use the hosting editor (VS Code or its fork) for editing files. Your lazygit config file is not affected.",
+          "enumDescriptions": [
+            "Disable editor integration. Lazygit uses its own configured editor.",
+            "Use VS Code CLI interface (e.g., `code -rg file:123`).",
+            "Use VS Code URL scheme (e.g., `vscode://file/...`). Can be much faster on some platforms."
+          ]
         },
         "lazygit-vscode.autoHideSideBar": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,9 +9,19 @@ import assert = require("assert");
 const LAZYGIT_TOGGLE_COMMAND = "lazygit-vscode.toggle";
 const LAZYGIT_CONTEXT_KEY = "lazygitFocus";
 
+const IS_WINDOWS = process.platform === "win32";
+const IS_MAC = process.platform === "darwin";
+
+const OPEN_URI_CMD = IS_WINDOWS ? 'start ""' : IS_MAC ? "open" : "xdg-open";
+
 let lazyGitTerminal: vscode.Terminal | undefined;
 let globalConfig: LazyGitConfig;
 let globalConfigJSON: string;
+let extensionContext: vscode.ExtensionContext;
+let lazyGitInjections: LazyGitInjectionConfig = {
+  extraConfigPath: "",
+  env: {}
+};
 
 /* --- Config --- */
 
@@ -26,9 +36,21 @@ interface PanelOptions {
 interface LazyGitConfig {
   lazyGitPath: string;
   configPath: string;
+  autoConfigLazygitEditor: "off" | "cli" | "urlScheme";
+  lazygitKeybindings: KeybindingsConfig;
   autoMaximizeWindow: boolean;
   panels: PanelOptions;
   venvActivationDelay: number;
+}
+
+interface LazyGitInjectionConfig {
+  extraConfigPath: string;
+  env: { [key: string]: string };
+}
+
+interface KeybindingsConfig {
+  toggle: string;
+  quit: string;
 }
 
 function loadConfig(): LazyGitConfig {
@@ -63,6 +85,14 @@ function loadConfig(): LazyGitConfig {
       secondarySidebar: getPanelBehavior("secondarySidebar"),
     },
     venvActivationDelay: config.get<number>("venvActivationDelay", 200),
+    autoConfigLazygitEditor: config.get<"off" | "cli" | "urlScheme">(
+      "autoConfigLazygitEditor",
+      "cli"
+    ),
+    lazygitKeybindings: {
+      toggle: config.get<string>("lazygitKeybindings.toggle", ""),
+      quit: config.get<string>("lazygitKeybindings.quit", ""),
+    },
   };
 }
 
@@ -106,11 +136,25 @@ async function loadExtension() {
     );
     globalConfig.configPath = "";
   }
+
+  // Resolve the actual Lazygit config file if we need to inject a second, VS Code-specific one
+  if (requiresConfigInjection()) {
+    if (!globalConfig.configPath) {
+      globalConfig.configPath = await resolveImplicitLazyGitConfigPath();
+      if (!globalConfig.configPath) {
+        vscode.window.showErrorMessage(
+          "Could not resolve LazyGit config path. Extra config won't be applied."
+        );
+      }
+    }
+    lazyGitInjections = await createLazygitInjections();
+  }
 }
 
 /* --- Events --- */
 
 export async function activate(context: vscode.ExtensionContext) {
+  extensionContext = context;
   async function toggleLazyGit() {
     if (lazyGitTerminal) {
       if (windowFocused()) { // Hide
@@ -134,10 +178,20 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(LAZYGIT_TOGGLE_COMMAND, toggleLazyGit),
     vscode.window.onDidChangeActiveTextEditor(updateLazyGitFocusContext),
     vscode.window.onDidChangeActiveTerminal(updateLazyGitFocusContext),
+    vscode.window.registerUriHandler(new LazygitUriHandler()),
   );
 }
 
 export function deactivate() {}
+
+// URI handler for custom Lazygit commands
+class LazygitUriHandler implements vscode.UriHandler {
+  public handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
+    if (uri.path === '/toggle') {
+      vscode.commands.executeCommand(LAZYGIT_TOGGLE_COMMAND);
+    }
+  }
+}
 
 /* ---  Window --- */
 
@@ -148,43 +202,42 @@ async function createWindow() {
 
   assert(globalConfig.lazyGitPath, "Uncaught error: lazygitpath is undefined!");
   let lazyGitCommand = globalConfig.lazyGitPath;
+
+  // Build --use-config-file: user config (if any) + generated editor config
+  const configFiles: string[] = [];
   if (globalConfig.configPath) {
-    lazyGitCommand += ` --use-config-file="${globalConfig.configPath}"`;
+    configFiles.push(globalConfig.configPath);
+  }
+  if (lazyGitInjections.extraConfigPath) {
+    configFiles.push(lazyGitInjections.extraConfigPath);
+  }
+  if (configFiles.length > 0) {
+    lazyGitCommand += ` --use-config-file="${configFiles.join(",")}"`;
   }
 
   // Check if Python venv activation is enabled
   const pythonConfig = vscode.workspace.getConfiguration("python");
   const activateEnvironment = pythonConfig.get<boolean>("terminal.activateEnvironment", true);
 
-  const env: { [key: string]: string } = {};
-  try {
-    let codePath = await findExecutableOnPath("code");
-    env.PATH = `"${codePath}"${path.delimiter}${process.env.PATH}`;
-  } catch (error) {
-    vscode.window.showWarningMessage(
-      "Could not find 'code' on PATH. Opening vscode windows with `e` may not work properly."
-    );
-  }
-
   // Determine shellArgs based on venv activation
   // If venv activation is enabled, use empty shellArgs and send command after delay
   // Otherwise, pass command directly to shell for immediate execution
   const shellArgs = activateEnvironment
     ? []
-    : process.platform === "win32"
-    ? ["/c", lazyGitCommand]
-    : ["-c", lazyGitCommand];
+    : IS_WINDOWS
+      ? ["/c", lazyGitCommand]
+      : ["-c", lazyGitCommand];
 
   lazyGitTerminal = vscode.window.createTerminal({
     name: "LazyGit",
     cwd: workspaceFolder,
     shellPath:
-      process.platform === "win32"
+      IS_WINDOWS
         ? "powershell.exe"
         : await findExecutableOnPath("bash"),
     shellArgs: shellArgs,
     location: vscode.TerminalLocation.Editor,
-    env: env,
+    env: lazyGitInjections.env,
   });
 
   focusWindow();
@@ -194,8 +247,7 @@ async function createWindow() {
   if (activateEnvironment) {
     setTimeout(() => {
       if (lazyGitTerminal) {
-        const exitCommand = process.platform === "win32" ? "; exit" : "; exit";
-        lazyGitTerminal.sendText(`${lazyGitCommand}${exitCommand}`);
+        lazyGitTerminal.sendText(`${lazyGitCommand}; exit`);
       }
     }, globalConfig.venvActivationDelay);
   }
@@ -309,13 +361,212 @@ function onHide() {
   }, timeoutValue);
 }
 
+/* --- Config Injection --- */
+
+async function createLazygitInjections(): Promise<LazyGitInjectionConfig> {
+  const res: LazyGitInjectionConfig = { extraConfigPath: "", env: {} };
+  const parts: string[] = [];
+
+  if (globalConfig.autoConfigLazygitEditor !== "off") {
+    // Resolve editor CLI and generate lazygit edit config
+    const cli = await resolveCliExecutable();
+    if (!cli) {
+      vscode.window.showErrorMessage(
+        "Could not resolve editor CLI. Opening files with `e` will use LazyGit defaults."
+      )
+      return res;
+    }
+
+    if (cli !== "") {
+      let edit: string;
+      let editAtLine: string;
+
+      if (globalConfig.autoConfigLazygitEditor === "urlScheme") {
+        const uriScheme = vscode.env.uriScheme;
+        const scriptPath = createProxyEditScript(uriScheme);
+        // Store the script path in an env variable to make Lazygit command log cleaner
+        res.env["EDIT"] = scriptPath;
+        edit = IS_WINDOWS ? `call "%EDIT%"` : `"$EDIT"`;
+        editAtLine = edit;
+      } else { // "cli"
+        edit = `${cli} -r`;
+        editAtLine = `${cli} -rg`;
+      }
+
+      // For editAtLineAndWait, we want the command to exit when the file (as opposed to the whole
+      // app) is closed. This looks possible only with CLI, so fallback to it for "urlScheme" too.
+      const editAndWait = `${cli} -rgw`;
+
+      parts.push(`os:
+  edit: '${edit} {{filename}}'
+  editAtLine: '${editAtLine} {{filename}}:{{line}}'
+  editAtLineAndWait: '${editAndWait} {{filename}}:{{line}}'
+  editInTerminal: false
+  openDirInEditor: '${edit} {{dir}}'`);
+    }
+  }
+
+  if (globalConfig.lazygitKeybindings.toggle) {
+    parts.push(`customCommands:
+  - key: '${globalConfig.lazygitKeybindings.toggle}'
+    command: "${OPEN_URI_CMD} '${vscode.env.uriScheme}://${extensionContext.extension.id}/toggle'"
+    context: 'global'
+    description: 'Toggle Lazygit in VS Code'`);
+  }
+
+  if (globalConfig.lazygitKeybindings.quit) {
+    parts.push(`keybinding:
+  universal:
+    quit: '${globalConfig.lazygitKeybindings.quit}'`);
+  }
+
+  const globalStorage = extensionContext.globalStorageUri.fsPath;
+  const configPath = path.join(globalStorage, "lazygit-editor.yml");
+  const content = parts.join('\n');
+
+  try {
+    updateFile(configPath, content);
+  } catch (error) {
+    vscode.window.showErrorMessage('Failed to write auto config file for Lazygit');
+    return res;
+  }
+
+  res.extraConfigPath = configPath;
+  return res;
+}
+
+// Generates a wrapper script that opens the URI scheme for the editor. The main reason for its
+// existence is to not pollute the Lazygit command log with long commands that come with having to
+// URL-encode stuff with built-in shell commands like `sed`.
+function createProxyEditScript(uriScheme: string): string {
+  // Rudimentary percent-encoding that is both too little (no brackets or unicode) and too much (one
+  // could argue nobody in their right mind would use anything but [A-Za-z0-9.-_] in filenames).
+  let filename: string;
+  let opts: fs.WriteFileOptions;
+  let content: string;
+  if (IS_WINDOWS) {
+    filename = "lazygit-open.cmd";
+    opts = {};
+    content = `@echo off
+setlocal enabledelayedexpansion
+set "P=%~1"
+set "P=!P:%%=%%25!"
+set "P=!P: =%%20!"
+set "P=!P:#=%%23!"
+set "P=!P:&=%%26!"
+set "P=!P:+=%%2B!"
+${OPEN_URI_CMD} "${uriScheme}://file/!P!"
+`;
+  } else {
+    filename = "lazygit-open.sh";
+    opts = { mode: 0o755 };
+    content = `eval "${OPEN_URI_CMD} \\"${uriScheme}://file/$(echo "$1" | \
+sed -e 's/%/%25/g' -e 's/ /%20/g' -e 's/#/%23/g' -e 's/&/%26/g' -e 's/+/%2B/g')\\""`;
+  }
+
+  const globalStorage = extensionContext.globalStorageUri.fsPath;
+  const scriptPath = path.join(globalStorage, filename);
+  try {
+    updateFile(scriptPath, content, opts);
+  } catch (error) {
+    vscode.window.showErrorMessage('Failed to write proxy edit script for Lazygit');
+    return "";
+  }
+  return scriptPath;
+}
+
 /* --- Utils --- */
+
+// Finds the VS Code (or fork) CLI executable name
+async function resolveCliExecutable(): Promise<string> {
+  const lowerAppName = vscode.env.appName.toLowerCase();
+  const root = vscode.env.appRoot;
+  const candidates = [
+    path.join(root, "bin"),
+    path.join(root, "..", "bin"),
+    path.join(root, "..", "..", "bin"),
+    path.join(root, "..", "..", "..", "bin")
+  ];
+
+  for (const dir of candidates) {
+    if (fs.existsSync(dir)) {
+      for (const f of fs.readdirSync(dir)) {
+        // It's .cmd on Windows, so drop the extension
+        const name = path.parse(f).name;
+        // Skip helpers like code-tunnel, cursor-tunnel,
+        // and check if the names match to be extra sure
+        if (!name.includes("-") && lowerAppName.includes(name)) {
+          // It should be OK to return just the executable name - it's going
+          // to look nice and concise in Lazygit's command log
+          try {
+            await findExecutableOnPath(f);
+            return f;
+          } catch (error) {
+            vscode.window.showErrorMessage(`Executable ${f} found, but not on PATH`);
+            return "";
+          }
+        }
+      }
+    }
+  }
+  return "";
+}
+
+function requiresConfigInjection(): boolean {
+  return globalConfig.autoConfigLazygitEditor !== "off"
+    || Object.values(globalConfig.lazygitKeybindings).some(Boolean);
+}
+
+// Finds the actual config path that Lazygit uses if --use-config-file is not provided.
+// We'll need to specify it explicitly if we want to add an extra VS Code-specific config file.
+async function resolveImplicitLazyGitConfigPath(): Promise<string> {
+  // Check LG_CONFIG_FILE env var first, then fallback to lazygit -cd
+  const envConfigPath = process.env.LG_CONFIG_FILE;
+  if (envConfigPath && fs.existsSync(envConfigPath)) {
+    return envConfigPath;
+  } else {
+    try {
+      const dir = await getLazyGitConfigDir();
+      const filepath = path.join(dir, "config.yml");
+      if (fs.existsSync(filepath)) {
+        return filepath;
+      }
+    } catch (error) {
+      // Unable, will default to empty string
+    }
+  }
+  return "";
+}
+
+function getLazyGitConfigDir(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(`"${globalConfig.lazyGitPath}" -cd`, (error, stdout) => {
+      if (error)
+        reject(new Error("Could not determine lazygit config directory"));
+      else resolve(stdout.trim());
+    });
+  });
+}
+
+function updateFile(filePath: string, content: string, opts?: fs.WriteFileOptions) {
+  // Check existing file content and avoid writing if unchanged
+  if (fs.existsSync(filePath)) {
+    const oldContent = fs.readFileSync(filePath, 'utf-8');
+    if (oldContent === content) {
+      return;
+    }
+  } else {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  }
+
+  fs.writeFileSync(filePath, content, opts);
+}
 
 function findExecutableOnPath(executable: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const workspaceFolder = getWorkspaceFolder();
     const command =
-      process.platform === "win32"
+      IS_WINDOWS
         ? `where ${executable}`
         : `cd "${workspaceFolder}" && which ${executable}`;
     exec(command, (error, stdout) => {
@@ -327,7 +578,7 @@ function findExecutableOnPath(executable: string): Promise<string> {
 
 function expandPath(pth: string): string {
   pth = pth.replace(/^~(?=$|\/|\\)/, os.homedir());
-  if (process.platform === "win32") {
+  if (IS_WINDOWS) {
     pth = pth.replace(/%([^%]+)%/g, (_, n) => process.env[n] || "");
   } else {
     pth = pth.replace(/\$([A-Za-z0-9_]+)/g, (_, n) => process.env[n] || "");


### PR DESCRIPTION
Sorry for the large diff, this is somewhat complicated, but I believe it smoothes a number of rough edges, for example:
- If a user uses a flavor other than MS VS Code (Cursor, Antigravity, VS Codium, you name it), they have to symlink `code`. Then redo it again when they try out another VS Code fork, and so on. Here the CLI executable is resolved automatically.
- One may prefer to use a terminal editor when using Lazygit in a standalone terminal, and VS Code when in VS Code. Now that no longer means dealing with two separate but mostly duplicate Lazygit config files.
- To hide Lazygit you either have to use a key combo, or use `q` but then you have to wait for it to teardown/startup again, and you lose the state it was in. This PR makes it possible to use a simple keybinding like `q` to hide Lazygit.

For the editor auto-config, I've added the URL scheme option because the CLI way seems to be painfully slow on macOS. Not sure about other platforms.