### PR TITLE
Feat: LazyGit startup is slowed by Python venv fallback path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,7 +172,7 @@ async function createWindow() {
 
   // Check if Python venv activation is enabled
   const pythonConfig = vscode.workspace.getConfiguration("python");
-  const activateEnvironment = pythonConfig.get<boolean>("terminal.activateEnvironment", true);
+  const activateEnvironment = pythonConfig.get<boolean>("terminal.activateEnvironment", false);
 
   if (activateEnvironment) {
     // Use default shell so Python extension can inject venv activation


### PR DESCRIPTION
When `python.terminal.activateEnvironment` is not explicitly configured, the extension defaults it to true.

This makes LazyGit go through the Python virtualenv workaround path: create a normal shell, wait for `venvActivationDelay`, then launch LazyGit via `sendText`. As a result, LazyGit startup is slower even when the user does not need Python venv activation.

Since LazyGit does not depend on Python environments, the fallback default should be false so it launches directly by default.