### PR TITLE
Run LazyGit in a maximized terminal panel with VS Code view shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # LazyGit for VSCode
 
-Native integration of LazyGit directly in a VSCode window (not an integrated terminal)
+Native integration of LazyGit in a maximized VSCode terminal panel.
 
 https://github.com/tom-pollak/lazygit-vscode/assets/26611948/5924db82-7937-4ed9-96ad-07963af4b56e
 
 ## Features
 
-- Toggle LazyGit in the full-screen editor within VSCode
+- Open LazyGit from the VSCode status bar
+- Toggle LazyGit in a maximized terminal panel within VSCode
 - Use a keyboard shortcut to quickly open or close LazyGit
 - Use `e` or `o` to open a file in a new tab from the lazygit window
 
@@ -30,19 +31,18 @@ promptToReturnFromSubprocess: false
 
 #### Sidebar show/hide inconsistencies
 
-VSCode doesn't offer an API for checking sidebar visibility ([issue](https://github.com/microsoft/vscode/issues/186581)), so `autoMaximizeWindow` and `lazygit-vscode.panels` settings may cause inconsistencies:
+VSCode doesn't offer an API for checking sidebar visibility ([issue](https://github.com/microsoft/vscode/issues/186581)), so `lazygit-vscode.panels` sidebar settings may cause inconsistencies:
 
-- `keep` with `autoMaximizeWindow` will always reopen the sidebar, even if it was already hidden
 - `hideRestore` will always restore the sidebar on close, even if it was already hidden
-- `secondarySidebar` defaults to `"hide"`, so it will always be hidden when toggling lazygit
+- The primary and secondary sidebars are always hidden while LazyGit is shown
 
-For perfect consistency where no sidepanel is touched, use `autoMaximizeWindow: false` and set all panels to `"keep"`.
+Use `hideRestore` only if you want a sidebar restored when LazyGit closes.
 
 Created VSCode issue to track: https://github.com/microsoft/vscode/issues/283331
 
 #### Python virtualenv
 
-**Python virtualenv interference**: If `python.terminal.activateEnvironment` is true in the settings, this extension will delay the launch of LazyGit by a fixed time, allowing vscode to start the python virtualenv. The delay is configurable via `lazygit-vscode.venvActivationDelay` (default: 100ms). If you still experience issues, you can:
+**Python virtualenv interference**: If `python.terminal.activateEnvironment` is true in the settings, this extension will delay the launch of LazyGit by a fixed time, allowing vscode to start the python virtualenv. The delay is configurable via `lazygit-vscode.venvActivationDelay` (default: 200ms). If you still experience issues, you can:
 
 1. Increase the delay setting if your environment takes longer to activate
 2. Disable automatic Python activation in terminals:
@@ -53,12 +53,15 @@ Created VSCode issue to track: https://github.com/microsoft/vscode/issues/283331
 
 #### Integrated shell keybindings
 
-Default cmd is ctrl+shift+l which may be captured by the shell. Ensure the following config
+The extension contributes its LazyGit commands to `terminal.integrated.commandsToSkipShell`, so the default shortcuts should be handled by VSCode instead of being sent to LazyGit. If you override terminal keyboard behavior globally, keep this setting compatible:
 
 ```javascript
-  "terminal.integrated.sendKeybindingsToShell": false, // ensure this is false
-  "terminal.integrated.commandsToSkipShell": ["lazygit-vscode.toggle", "workbench.action.closeWindow"], // add this
+  "terminal.integrated.sendKeybindingsToShell": false
 ```
+
+Terminals do not reliably preserve `Shift` on control-letter shortcuts. Depending on the OS, input method, and VSCode terminal layer, `Ctrl+Shift+E`/`Ctrl+Shift+F`/`Ctrl+Shift+D`/`Ctrl+Shift+X` may either be consumed before LazyGit sees them or arrive as plain control-letter keys. The extension enables `lazygit-vscode.terminalKeybindingFallback` by default to inject temporary LazyGit custom commands for `Ctrl+E`, `Ctrl+F`, `Ctrl+D`, and `Ctrl+X` while LazyGit is launched from VSCode. Disable that setting if you need LazyGit's original control-letter behavior.
+
+The extension also binds `Ctrl+E`, `Ctrl+F`, `Ctrl+D`, and `Ctrl+X` directly while the VSCode terminal is focused on LazyGit. This is scoped to LazyGit only and is intended to catch terminals that normalize shifted control-letter shortcuts before VSCode can resolve the original keybinding.
 
 ## Requirements
 
@@ -66,35 +69,64 @@ Default cmd is ctrl+shift+l which may be captured by the shell. Ensure the follo
 
 ## Usage
 
-Use the keyboard shortcut `Ctrl+Shift+L` (or `Cmd+Shift+L` on macOS) to toggle LazyGit
+Use the `LazyGit` status bar item to open LazyGit, or use the keyboard shortcut `Ctrl+Shift+L` (or `Cmd+Shift+L` on macOS) to toggle LazyGit. LazyGit opens in the terminal panel; the extension moves the panel to the bottom, center-aligns it, and maximizes it to push the editor area out of the way.
 
+- `lazygit-vscode.open`: Open LazyGit
 - `lazygit-vscode.toggle`: Toggle LazyGit
+- `lazygit-vscode.showExplorer`: Hide LazyGit and show Explorer
+- `lazygit-vscode.showSearch`: Hide LazyGit and show Search
+- `lazygit-vscode.showDebug`: Hide LazyGit and show Run and Debug
+- `lazygit-vscode.showExtensions`: Hide LazyGit and show Extensions
 - `lazygitFocus`: When clause for your keybindings.
+
+When LazyGit has terminal focus, use `Ctrl+E` to show Explorer, `Ctrl+F` to show Search, `Ctrl+D` to show Run and Debug, and `Ctrl+X` to show Extensions. Outside the LazyGit terminal, the normal VSCode shortcuts keep their default behavior.
+
+Because LazyGit runs in VSCode's terminal panel, VSCode still shows terminal panel chrome such as the panel tabs and terminal list. Extensions cannot make the terminal panel a fully standalone surface.
+
+Clicking VSCode's built-in Activity Bar icons uses internal workbench commands that extensions cannot intercept. Use the LazyGit keyboard commands above when you want LazyGit to close before opening Explorer, Search, Run and Debug, or Extensions.
+
+## Local development
+
+To test the extension locally before publishing or opening a PR:
+
+1. Run `npm ci`
+2. Run `npm run compile`
+3. Launch an Extension Development Host from this repository:
+
+```bash
+code --extensionDevelopmentPath="$(pwd)" --new-window .
+```
+
+This opens a separate VSCode window with this workspace loaded as the extension under test. Use that new window to verify the LazyGit status bar item and `Ctrl+Shift+L` behavior.
+
+Do not use `Developer: Debug Extension Host` for this flow; that command debugs the current VSCode extension host and does not launch this repository as a development extension.
 
 ## Extension Settings
 
 ### Basic Configuration
 
 - `lazygit-vscode.nativeFileOpening`: Automatically handle file opening from lazygit via IPC (default: `true`). When enabled, pressing `e` opens files directly in VSCode without needing `code` on PATH or `editPreset: "vscode"` in your lazygit config. Set to `false` to fall back to the `code` CLI approach.
+- `lazygit-vscode.terminalKeybindingFallback`: Inject temporary LazyGit custom commands for `Ctrl+E`, `Ctrl+F`, `Ctrl+D`, and `Ctrl+X` so VSCode view shortcuts still work when VSCode's terminal sends control-letter shortcuts into LazyGit (default: `true`).
 - `lazygit-vscode.lazygitPath`: Manually set LazyGit path. Otherwise use default system PATH.
 - `lazygit-vscode.configPath`: Set custom LazyGit config. Useful if you like different behaviour between VSCode and CLI.
-- `lazygit-vscode.autoMaximizeWindow`: Maximize the lazygit window in the editor (keeps sidebar visible). Useful when working with split editors.
+- `lazygit-vscode.autoMaximizeWindow`: Deprecated. LazyGit now opens in a maximized terminal panel.
 - `lazygit-vscode.venvActivationDelay`: Delay in milliseconds to wait for Python virtual environment activation before launching lazygit (default: 200). Increase this value if your Python environment takes longer to activate.
 
 ### Panel Behavior
 
-You can control how LazyGit interacts with VS Code UI panels using the `panels` setting. Each panel can be set to:
+LazyGit always hides the primary and secondary sidebars while shown. You can control whether each sidebar is restored when LazyGit closes:
 
-- `"keep"`: Leave panel as is (default)
-- `"hide"`: Hide the panel when showing LazyGit
-- `"hideRestore"`: Hide the panel when showing LazyGit and restore it when closing
+- `"keep"`: Do not restore the sidebar when LazyGit closes
+- `"hide"`: Do not restore the sidebar when LazyGit closes
+- `"hideRestore"`: Restore the sidebar when LazyGit closes
+
+The `panel` option is deprecated because LazyGit now runs in the terminal panel.
 
 Example configuration:
 
 ```json
 "lazygit-vscode.panels": {
   "sidebar": "hideRestore",
-  "panel": "hide",
   "secondarySidebar": "keep"
 }
 ```
@@ -102,7 +134,7 @@ Example configuration:
 #### Available Panels
 
 - `lazygit-vscode.panels.sidebar`: Primary sidebar (Explorer, Source Control, etc.)
-- `lazygit-vscode.panels.panel`: Bottom panel (Terminal, Output, etc.)
+- `lazygit-vscode.panels.panel`: Deprecated. LazyGit now runs in the terminal panel, so this setting is ignored.
 - `lazygit-vscode.panels.secondarySidebar`: Secondary sidebar (usually on the right side)
 
 > Note: Legacy settings `autoHideSideBar` and `autoHidePanel` are still supported but deprecated.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lazygit-vscode",
   "displayName": "LazyGit VSCode",
-  "description": "Native integration of LazyGit directly in a VSCode window",
+  "description": "Native integration of LazyGit in a maximized VSCode terminal panel",
   "version": "0.1.26",
   "publisher": "TomPollak",
   "engines": {
@@ -13,20 +13,100 @@
   },
   "icon": "logo.png",
   "categories": [],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
+      {
+        "command": "lazygit-vscode.open",
+        "title": "LazyGit: Open"
+      },
+      {
+        "command": "lazygit-vscode.showExplorer",
+        "title": "LazyGit: Show Explorer"
+      },
+      {
+        "command": "lazygit-vscode.showSearch",
+        "title": "LazyGit: Show Search"
+      },
+      {
+        "command": "lazygit-vscode.showDebug",
+        "title": "LazyGit: Show Run and Debug"
+      },
+      {
+        "command": "lazygit-vscode.showExtensions",
+        "title": "LazyGit: Show Extensions"
+      },
       {
         "command": "lazygit-vscode.toggle",
         "title": "LazyGit: Toggle"
       }
     ],
+    "configurationDefaults": {
+      "terminal.integrated.commandsToSkipShell": [
+        "lazygit-vscode.open",
+        "lazygit-vscode.toggle",
+        "lazygit-vscode.showExplorer",
+        "lazygit-vscode.showSearch",
+        "lazygit-vscode.showDebug",
+        "lazygit-vscode.showExtensions"
+      ]
+    },
     "keybindings": [
       {
         "command": "lazygit-vscode.toggle",
         "key": "ctrl+shift+l",
         "mac": "cmd+shift+l"
+      },
+      {
+        "command": "lazygit-vscode.showExplorer",
+        "key": "ctrl+shift+e",
+        "mac": "cmd+shift+e",
+        "when": "terminalFocus && lazygitFocus"
+      },
+      {
+        "command": "lazygit-vscode.showExplorer",
+        "key": "ctrl+e",
+        "mac": "ctrl+e",
+        "when": "terminalFocus && lazygitFocus"
+      },
+      {
+        "command": "lazygit-vscode.showSearch",
+        "key": "ctrl+shift+f",
+        "mac": "cmd+shift+f",
+        "when": "terminalFocus && lazygitFocus"
+      },
+      {
+        "command": "lazygit-vscode.showSearch",
+        "key": "ctrl+f",
+        "mac": "ctrl+f",
+        "when": "terminalFocus && lazygitFocus"
+      },
+      {
+        "command": "lazygit-vscode.showDebug",
+        "key": "ctrl+shift+d",
+        "mac": "cmd+shift+d",
+        "when": "terminalFocus && lazygitFocus"
+      },
+      {
+        "command": "lazygit-vscode.showDebug",
+        "key": "ctrl+d",
+        "mac": "ctrl+d",
+        "when": "terminalFocus && lazygitFocus"
+      },
+      {
+        "command": "lazygit-vscode.showExtensions",
+        "key": "ctrl+shift+x",
+        "mac": "cmd+shift+x",
+        "when": "terminalFocus && lazygitFocus"
+      },
+      {
+        "command": "lazygit-vscode.showExtensions",
+        "key": "ctrl+x",
+        "mac": "ctrl+x",
+        "when": "terminalFocus && lazygitFocus"
       }
     ],
     "configuration": {
@@ -53,12 +133,12 @@
                 "hide",
                 "hideRestore"
               ],
-              "default": "keep",
-              "description": "Sidebar behavior when showing lazygit",
+              "default": "hide",
+              "description": "Sidebar restore behavior. LazyGit always hides the primary sidebar while shown.",
               "enumDescriptions": [
-                "Keep sidebar as is",
-                "Hide sidebar when showing lazygit",
-                "Hide sidebar when showing lazygit and restore when closing"
+                "Do not restore the primary sidebar when LazyGit closes",
+                "Do not restore the primary sidebar when LazyGit closes",
+                "Restore the primary sidebar when LazyGit closes"
               ]
             },
             "panel": {
@@ -69,7 +149,8 @@
                 "hideRestore"
               ],
               "default": "keep",
-              "description": "Panel behavior when showing lazygit",
+              "description": "Deprecated. LazyGit now runs in the terminal panel, so this setting is ignored.",
+              "markdownDeprecationMessage": "**Deprecated**: LazyGit now runs in the terminal panel, so this setting is ignored.",
               "enumDescriptions": [
                 "Keep panel as is",
                 "Hide panel when showing lazygit",
@@ -84,11 +165,11 @@
                 "hideRestore"
               ],
               "default": "hide",
-              "description": "Secondary sidebar behavior when showing lazygit",
+              "description": "Secondary sidebar restore behavior. LazyGit always hides the secondary sidebar while shown.",
               "enumDescriptions": [
-                "Keep secondary sidebar as is",
-                "Hide secondary sidebar when showing lazygit",
-                "Hide secondary sidebar when showing lazygit and restore when closing"
+                "Do not restore the secondary sidebar when LazyGit closes",
+                "Do not restore the secondary sidebar when LazyGit closes",
+                "Restore the secondary sidebar when LazyGit closes"
               ]
             }
           }
@@ -99,11 +180,18 @@
           "scope": "window",
           "default": true
         },
+        "lazygit-vscode.terminalKeybindingFallback": {
+          "type": "boolean",
+          "description": "Inject temporary LazyGit custom commands for Ctrl+E, Ctrl+F, Ctrl+D, and Ctrl+X so VSCode views can still be opened when the integrated terminal sends control-letter shortcuts into LazyGit instead of VSCode.",
+          "scope": "window",
+          "default": true
+        },
         "lazygit-vscode.autoMaximizeWindow": {
           "type": "boolean",
-          "description": "Maximize the lazygit window in editor",
+          "description": "Deprecated. LazyGit now opens in a maximized terminal panel.",
           "scope": "window",
-          "default": false
+          "default": false,
+          "markdownDeprecationMessage": "**Deprecated**: LazyGit now opens in a maximized terminal panel."
         },
         "lazygit-vscode.venvActivationDelay": {
           "type": "number",
@@ -121,7 +209,7 @@
           "type": "boolean",
           "description": "Auto-hide the panel when showing lazygit",
           "scope": "window",
-          "markdownDeprecationMessage": "**Deprecated**: Use `panels.panel: \"hide\"` or `panels.panel: \"hideRestore\"` instead"
+          "markdownDeprecationMessage": "**Deprecated**: LazyGit now runs in the terminal panel, so this setting is ignored."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,14 +6,68 @@ import * as process from "process";
 import { exec } from "child_process";
 import assert = require("assert");
 
-
+const LAZYGIT_OPEN_COMMAND = "lazygit-vscode.open";
+const LAZYGIT_SHOW_EXPLORER_COMMAND = "lazygit-vscode.showExplorer";
+const LAZYGIT_SHOW_SEARCH_COMMAND = "lazygit-vscode.showSearch";
+const LAZYGIT_SHOW_DEBUG_COMMAND = "lazygit-vscode.showDebug";
+const LAZYGIT_SHOW_EXTENSIONS_COMMAND = "lazygit-vscode.showExtensions";
 const LAZYGIT_TOGGLE_COMMAND = "lazygit-vscode.toggle";
 const LAZYGIT_CONTEXT_KEY = "lazygitFocus";
+const IPC_COMMAND_PREFIX = "::lazygit-vscode::";
+const IPC_SHOW_EXPLORER = "showExplorer";
+const IPC_SHOW_SEARCH = "showSearch";
+const IPC_SHOW_DEBUG = "showDebug";
+const IPC_SHOW_EXTENSIONS = "showExtensions";
+
+interface WorkbenchViewTarget {
+  command: string;
+  viewCommand: string;
+  ipcCommand: string;
+  lazygitKey: string;
+  description: string;
+}
+
+const WORKBENCH_VIEW_TARGETS: WorkbenchViewTarget[] = [
+  {
+    command: LAZYGIT_SHOW_EXPLORER_COMMAND,
+    viewCommand: "workbench.view.explorer",
+    ipcCommand: IPC_SHOW_EXPLORER,
+    lazygitKey: "<c-e>",
+    description: "Show VSCode Explorer",
+  },
+  {
+    command: LAZYGIT_SHOW_SEARCH_COMMAND,
+    viewCommand: "workbench.view.search",
+    ipcCommand: IPC_SHOW_SEARCH,
+    lazygitKey: "<c-f>",
+    description: "Show VSCode Search",
+  },
+  {
+    command: LAZYGIT_SHOW_DEBUG_COMMAND,
+    viewCommand: "workbench.view.debug",
+    ipcCommand: IPC_SHOW_DEBUG,
+    lazygitKey: "<c-d>",
+    description: "Show VSCode Run and Debug",
+  },
+  {
+    command: LAZYGIT_SHOW_EXTENSIONS_COMMAND,
+    viewCommand: "workbench.view.extensions",
+    ipcCommand: IPC_SHOW_EXTENSIONS,
+    lazygitKey: "<c-x>",
+    description: "Show VSCode Extensions",
+  },
+];
 
 let lazyGitTerminal: vscode.Terminal | undefined;
+let lazyGitOpening: Promise<void> | undefined;
+let lazyGitPanelVisible = false;
+let lazyGitPanelMaximized = false;
 let globalConfig: LazyGitConfig;
 let globalConfigJSON: string;
-let ipcState: { ipcPath: string; overlayPath: string; watcher: fs.FSWatcher } | undefined;
+let ipcState:
+  | { ipcPath: string; overlayPath: string; watcher: fs.FSWatcher }
+  | undefined;
+let terminalCloseSubscription: vscode.Disposable | undefined;
 
 /* --- Config --- */
 
@@ -32,6 +86,7 @@ interface LazyGitConfig {
   panels: PanelOptions;
   venvActivationDelay: number;
   nativeFileOpening: boolean;
+  terminalKeybindingFallback: boolean;
 }
 
 function loadConfig(): LazyGitConfig {
@@ -39,7 +94,7 @@ function loadConfig(): LazyGitConfig {
 
   // Helper function for getting panel behavior with legacy fallback
   function getPanelBehavior(panelName: string): PanelBehavior {
-    const defaultValue = panelName === "secondarySidebar" ? "hide" : "keep";
+    const defaultValue = panelName === "panel" ? "keep" : "hide";
     const newSetting = config.get<PanelBehavior>(
       `panels.${panelName}`,
       defaultValue
@@ -48,9 +103,13 @@ function loadConfig(): LazyGitConfig {
 
     // Legacy fallbacks for published settings
     if (panelName === "sidebar") {
-      return config.get<boolean>("autoHideSideBar", false) ? "hide" : "keep";
+      return config.get<boolean>("autoHideSideBar", false)
+        ? "hide"
+        : defaultValue;
     } else if (panelName === "panel") {
-      return config.get<boolean>("autoHidePanel", false) ? "hide" : "keep";
+      return config.get<boolean>("autoHidePanel", false)
+        ? "hide"
+        : defaultValue;
     }
 
     return defaultValue;
@@ -67,6 +126,10 @@ function loadConfig(): LazyGitConfig {
     },
     venvActivationDelay: config.get<number>("venvActivationDelay", 200),
     nativeFileOpening: config.get<boolean>("nativeFileOpening", true),
+    terminalKeybindingFallback: config.get<boolean>(
+      "terminalKeybindingFallback",
+      true
+    ),
   };
 }
 
@@ -115,27 +178,27 @@ async function loadExtension() {
 /* --- Events --- */
 
 export async function activate(context: vscode.ExtensionContext) {
-  async function toggleLazyGit() {
-    if (lazyGitTerminal) {
-      if (windowFocused()) { // Hide
-        closeWindow();
-        onHide();
-      } else { // Show
-        focusWindow();
-        onShown();
-      }
-    } else { // No lazyGitTerminal, create new one.
-      await createWindow();
-      onShown();
-    }
-  }
-
-  const updateLazyGitFocusContext = () => {
-    vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, windowFocused());
-  };
+  const updateLazyGitFocusContext = () =>
+    setLazyGitFocusContext(isLazyGitTerminalActive());
+  const lazyGitStatusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    100
+  );
+  lazyGitStatusBarItem.name = "LazyGit";
+  lazyGitStatusBarItem.text = "$(source-control) LazyGit";
+  lazyGitStatusBarItem.tooltip = "Open LazyGit";
+  lazyGitStatusBarItem.command = LAZYGIT_OPEN_COMMAND;
+  lazyGitStatusBarItem.show();
 
   context.subscriptions.push(
+    vscode.commands.registerCommand(LAZYGIT_OPEN_COMMAND, openLazyGit),
+    ...WORKBENCH_VIEW_TARGETS.map(({ command, viewCommand }) =>
+      vscode.commands.registerCommand(command, () =>
+        showWorkbenchView(viewCommand).then(undefined, showLazyGitError)
+      )
+    ),
     vscode.commands.registerCommand(LAZYGIT_TOGGLE_COMMAND, toggleLazyGit),
+    lazyGitStatusBarItem,
     vscode.window.onDidChangeActiveTextEditor(updateLazyGitFocusContext),
     vscode.window.onDidChangeActiveTerminal(updateLazyGitFocusContext),
   );
@@ -143,9 +206,58 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {
   cleanupIpc();
+  terminalCloseSubscription?.dispose();
+  terminalCloseSubscription = undefined;
 }
 
 /* ---  Window --- */
+
+function openLazyGit() {
+  showLazyGit().then(undefined, showLazyGitError);
+}
+
+async function showWorkbenchView(command: string) {
+  if (lazyGitPanelVisible) {
+    await closeLazyGitPanel();
+    onHide(false);
+  }
+
+  await vscode.commands.executeCommand(command);
+}
+
+async function showLazyGit() {
+  if (lazyGitOpening) {
+    await lazyGitOpening;
+    return;
+  }
+
+  if (lazyGitTerminal) {
+    const shouldMaximize = !lazyGitPanelVisible;
+    focusWindow();
+    await onShown(shouldMaximize);
+    return;
+  }
+
+  lazyGitOpening = createWindow()
+    .then(() => onShown(true))
+    .finally(() => {
+      lazyGitOpening = undefined;
+    });
+  await lazyGitOpening;
+}
+
+async function toggleLazyGit() {
+  if (lazyGitTerminal && lazyGitPanelVisible) {
+    await closeWindow();
+  } else {
+    await showLazyGit();
+  }
+}
+
+function showLazyGitError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  vscode.window.showErrorMessage(`Failed to open LazyGit: ${message}`);
+}
 
 async function createWindow() {
   await reloadIfConfigChange();
@@ -162,7 +274,10 @@ async function createWindow() {
   // Ensure the terminal inherits the extension host's full PATH
   env.PATH = process.env.PATH || "";
 
-  if (globalConfig.nativeFileOpening) {
+  if (
+    globalConfig.nativeFileOpening ||
+    globalConfig.terminalKeybindingFallback
+  ) {
     const ipc = setupIpc();
     configFileArg = ipc.configFileArg;
     ipcState = { ...ipc, watcher: startIpcWatcher(ipc.ipcPath) };
@@ -172,7 +287,10 @@ async function createWindow() {
 
   // Check if Python venv activation is enabled
   const pythonConfig = vscode.workspace.getConfiguration("python");
-  const activateEnvironment = pythonConfig.get<boolean>("terminal.activateEnvironment", false);
+  const activateEnvironment = pythonConfig.get<boolean>(
+    "terminal.activateEnvironment",
+    false
+  );
 
   if (activateEnvironment) {
     // Use default shell so Python extension can inject venv activation
@@ -185,7 +303,7 @@ async function createWindow() {
     lazyGitTerminal = vscode.window.createTerminal({
       name: "LazyGit",
       cwd: workspaceFolder,
-      location: vscode.TerminalLocation.Editor,
+      location: vscode.TerminalLocation.Panel,
       env: env,
     });
 
@@ -207,7 +325,7 @@ async function createWindow() {
       cwd: workspaceFolder,
       shellPath: globalConfig.lazyGitPath,
       shellArgs: shellArgs,
-      location: vscode.TerminalLocation.Editor,
+      location: vscode.TerminalLocation.Panel,
       env: env,
     });
 
@@ -215,20 +333,15 @@ async function createWindow() {
   }
 
   // lazygit window closes, unlink and focus on editor (where lazygit was)
-  vscode.window.onDidCloseTerminal((terminal) => {
+  terminalCloseSubscription?.dispose();
+  terminalCloseSubscription = vscode.window.onDidCloseTerminal((terminal) => {
     if (terminal === lazyGitTerminal) {
       lazyGitTerminal = undefined;
+      lazyGitPanelVisible = false;
       cleanupIpc();
-      onHide();
+      closeLazyGitPanel().then(() => onHide(true), showLazyGitError);
     }
   });
-}
-
-function windowFocused(): boolean {
-  return (
-    vscode.window.activeTextEditor === undefined &&
-    vscode.window.activeTerminal === lazyGitTerminal
-  );
 }
 
 function focusWindow() {
@@ -236,63 +349,53 @@ function focusWindow() {
   lazyGitTerminal.show(false); // false: take focus
 }
 
-function closeWindow() {
-  const openTabs = vscode.window.tabGroups.all.flatMap(
-    (group) => group.tabs
-  ).length;
-  if (openTabs === 1 && lazyGitTerminal) {
-    // only lazygit tab, close
-    lazyGitTerminal.dispose();
-  } else {
-    // toggle recently used tab in group
-    vscode.commands.executeCommand(
-      "workbench.action.openPreviousRecentlyUsedEditorInGroup"
-    );
+function isLazyGitTerminalActive(): boolean {
+  return vscode.window.activeTerminal === lazyGitTerminal;
+}
+
+function setLazyGitFocusContext(value: boolean) {
+  vscode.commands.executeCommand("setContext", LAZYGIT_CONTEXT_KEY, value);
+}
+
+async function closeWindow() {
+  await closeLazyGitPanel();
+  onHide(true);
+}
+
+async function onShown(maximizePanel: boolean) {
+  focusWindow();
+  lazyGitPanelVisible = true;
+  setLazyGitFocusContext(true);
+
+  await vscode.commands.executeCommand("workbench.action.closeSidebar");
+  await vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
+
+  if (maximizePanel) {
+    await maximizeLazyGitPanel();
   }
 }
 
-function onShown() {
-  const shouldKeep = (behavior: PanelBehavior) => behavior === "keep";
-  const shouldHide = (behavior: PanelBehavior) =>
-    behavior === "hide" || behavior === "hideRestore";
-
-  if (globalConfig.autoMaximizeWindow) {
-    vscode.commands.executeCommand(
-      "workbench.action.maximizeEditorHideSidebar"
-    );
-
-    // maximizeEditorHideSidebar closes both sidebars. If keep is true, we need to open them again.
-    if (shouldKeep(globalConfig.panels.sidebar)) {
-      vscode.commands.executeCommand(
-        "workbench.action.toggleSidebarVisibility"
-      );
-    }
-    if (shouldKeep(globalConfig.panels.secondarySidebar)) {
-      vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar");
-      setTimeout(() => {
-        vscode.commands.executeCommand(
-          "workbench.action.focusActiveEditorGroup"
-        );
-      }, 200);
-    }
-  } else {
-    // autoMaximizeWindow: false
-    if (shouldHide(globalConfig.panels.sidebar)) {
-      vscode.commands.executeCommand("workbench.action.closeSidebar");
-    }
-
-    if (shouldHide(globalConfig.panels.secondarySidebar)) {
-      vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
-    }
-  }
-
-  // Bottom panel not affected by autoMaximizeWindow
-  if (shouldHide(globalConfig.panels.panel)) {
-    vscode.commands.executeCommand("workbench.action.closePanel");
-  }
+async function maximizeLazyGitPanel() {
+  await vscode.commands.executeCommand("workbench.action.positionPanelBottom");
+  await delay(50);
+  await vscode.commands.executeCommand("workbench.action.alignPanelCenter");
+  await delay(50);
+  await vscode.commands.executeCommand("workbench.action.toggleMaximizedPanel");
+  lazyGitPanelMaximized = true;
 }
 
-function onHide() {
+async function closeLazyGitPanel() {
+  if (lazyGitPanelMaximized) {
+    await vscode.commands.executeCommand("workbench.action.toggleMaximizedPanel");
+    lazyGitPanelMaximized = false;
+  }
+
+  lazyGitPanelVisible = false;
+  setLazyGitFocusContext(false);
+  await vscode.commands.executeCommand("workbench.action.closePanel");
+}
+
+function onHide(focusEditor: boolean) {
   // Restore panels
   const shouldRestore = (behavior: PanelBehavior) => behavior === "hideRestore";
 
@@ -304,18 +407,12 @@ function onHide() {
     vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar");
   }
 
-  if (shouldRestore(globalConfig.panels.panel)) {
-    vscode.commands.executeCommand("workbench.action.togglePanel");
+  if (!focusEditor) {
+    return;
   }
 
-  // Unmaximize
-  if (globalConfig.autoMaximizeWindow) {
-    vscode.commands.executeCommand("workbench.action.evenEditorWidths");
-  }
-
-  // Editor Focus -- panel / auxiliaryBar will take focus so short delay required
+  // Editor Focus -- auxiliaryBar will take focus so short delay required
   const timeoutValue =
-    globalConfig.panels.panel === "hideRestore" ||
     globalConfig.panels.secondarySidebar === "hideRestore"
       ? 200
       : 0;
@@ -328,10 +425,10 @@ function onHide() {
 
 function findExecutableOnPath(executable: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const workspaceFolder = getWorkspaceFolder();
-    const command = process.platform === "win32"
-      ? `where ${executable}`
-      : `${process.env.SHELL || "sh"} -lc "which ${executable}"`;
+    const command =
+      process.platform === "win32"
+        ? `where ${executable}`
+        : `${process.env.SHELL || "sh"} -lc "which ${executable}"`;
     exec(command, (error, stdout) => {
       if (error) reject(new Error(`${executable} not found on PATH`));
       else resolve(stdout.trim());
@@ -347,6 +444,10 @@ function expandPath(pth: string): string {
     pth = pth.replace(/\$([A-Za-z0-9_]+)/g, (_, n) => process.env[n] || "");
   }
   return pth;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function getWorkspaceFolder(): string {
@@ -372,7 +473,13 @@ function getDefaultLazygitConfigPath(): string {
       if (process.env.XDG_CONFIG_HOME) {
         return path.join(process.env.XDG_CONFIG_HOME, "lazygit", "config.yml");
       }
-      return path.join(os.homedir(), "Library", "Application Support", "lazygit", "config.yml");
+      return path.join(
+        os.homedir(),
+        "Library",
+        "Application Support",
+        "lazygit",
+        "config.yml"
+      );
     case "win32":
       return path.join(process.env.APPDATA || "", "lazygit", "config.yml");
     default:
@@ -383,17 +490,19 @@ function getDefaultLazygitConfigPath(): string {
   }
 }
 
-function setupIpc(): { ipcPath: string; overlayPath: string; configFileArg: string } {
+function setupIpc(): {
+  ipcPath: string;
+  overlayPath: string;
+  configFileArg: string;
+} {
   const tmpDir = os.tmpdir();
   const suffix = `${Date.now()}-${process.pid}`;
 
   const ipcPath = path.join(tmpDir, `lazygit-vscode-ipc-${suffix}.tmp`);
   fs.writeFileSync(ipcPath, "");
-
   const overlayYaml = [
-    "os:",
-    `  edit: 'printf "%s\\t0\\n" "{{filename}}" > "${ipcPath}"'`,
-    `  editAtLine: 'printf "%s\\t%s\\n" "{{filename}}" "{{line}}" > "${ipcPath}"'`,
+    ...getNativeFileOpeningYaml(ipcPath),
+    ...getTerminalKeybindingFallbackYaml(ipcPath),
     "notARepository: skip",
     "promptToReturnFromSubprocess: false",
     "",
@@ -404,7 +513,8 @@ function setupIpc(): { ipcPath: string; overlayPath: string; configFileArg: stri
 
   // --use-config-file replaces the default config, so include user config first,
   // then overlay (later files take priority via lazygit's deep merge)
-  const userConfigPath = globalConfig.configPath || getDefaultLazygitConfigPath();
+  const userConfigPath =
+    globalConfig.configPath || getDefaultLazygitConfigPath();
   const configFiles: string[] = [];
   if (fs.existsSync(userConfigPath)) {
     configFiles.push(userConfigPath);
@@ -414,16 +524,73 @@ function setupIpc(): { ipcPath: string; overlayPath: string; configFileArg: stri
   return { ipcPath, overlayPath, configFileArg: configFiles.join(",") };
 }
 
+function getNativeFileOpeningYaml(ipcPath: string): string[] {
+  if (!globalConfig.nativeFileOpening) {
+    return [];
+  }
+
+  return [
+    "os:",
+    `  edit: 'printf "%s\\t0\\n" "{{filename}}" > "${ipcPath}"'`,
+    `  editAtLine: 'printf "%s\\t%s\\n" "{{filename}}" "{{line}}" > "${ipcPath}"'`,
+  ];
+}
+
+function getTerminalKeybindingFallbackYaml(ipcPath: string): string[] {
+  if (!globalConfig.terminalKeybindingFallback) {
+    return [];
+  }
+
+  return [
+    "keybinding:",
+    "  universal:",
+    "    diffingMenu-alt: '<disabled>'",
+    "    scrollDownMain-alt2: '<disabled>'",
+    "  files:",
+    "    findBaseCommitForFixup: '<disabled>'",
+    "customCommands:",
+    ...WORKBENCH_VIEW_TARGETS.flatMap((target) =>
+      getCustomCommandYaml(ipcPath, target)
+    ),
+  ];
+}
+
+function getCustomCommandYaml(
+  ipcPath: string,
+  target: WorkbenchViewTarget
+): string[] {
+  const command = createIpcWriteCommand(
+    ipcPath,
+    `${IPC_COMMAND_PREFIX}${target.ipcCommand}`
+  );
+
+  return [
+    `  - key: '${target.lazygitKey}'`,
+    "    context: 'global'",
+    `    command: ${toYamlString(command)}`,
+    `    description: '${target.description}'`,
+    "    output: none",
+  ];
+}
+
 function startIpcWatcher(ipcPath: string): fs.FSWatcher {
   return fs.watch(ipcPath, () => {
     const content = fs.readFileSync(ipcPath, "utf8").trim();
-    if (content) {
-      handleIpcMessage(content);
+    if (!content) {
+      return;
     }
+
+    fs.writeFileSync(ipcPath, "");
+    handleIpcMessage(content).then(undefined, showLazyGitError);
   });
 }
 
-function handleIpcMessage(line: string) {
+async function handleIpcMessage(line: string) {
+  if (line.startsWith(IPC_COMMAND_PREFIX)) {
+    await handleIpcCommand(line.slice(IPC_COMMAND_PREFIX.length));
+    return;
+  }
+
   const parts = line.split("\t");
   const filePath = parts[0]?.trim();
   const lineNum = parts.length > 1 ? parseInt(parts[1], 10) : 0;
@@ -431,24 +598,76 @@ function handleIpcMessage(line: string) {
   if (!filePath) return;
 
   const uri = vscode.Uri.file(filePath);
-  vscode.workspace.openTextDocument(uri).then(
-    (doc) => {
-      const position = new vscode.Position(Math.max(0, lineNum > 0 ? lineNum - 1 : 0), 0);
-      vscode.window.showTextDocument(doc, {
-        preview: false,
-        selection: new vscode.Range(position, position),
-      });
-    },
-    () => {
-      vscode.window.showErrorMessage(`Failed to open file: ${filePath}`);
-    }
+  try {
+    await closeLazyGitPanel();
+    onHide(false);
+
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const position = new vscode.Position(
+      Math.max(0, lineNum > 0 ? lineNum - 1 : 0),
+      0
+    );
+    await vscode.window.showTextDocument(doc, {
+      preview: false,
+      selection: new vscode.Range(position, position),
+    });
+  } catch {
+    vscode.window.showErrorMessage(`Failed to open file: ${filePath}`);
+  }
+}
+
+async function handleIpcCommand(command: string) {
+  const target = WORKBENCH_VIEW_TARGETS.find(
+    (viewTarget) => viewTarget.ipcCommand === command
   );
+  if (target) {
+    await showWorkbenchView(target.viewCommand);
+  }
 }
 
 function cleanupIpc() {
   if (!ipcState) return;
   ipcState.watcher.close();
-  fs.unlinkSync(ipcState.ipcPath);
-  fs.unlinkSync(ipcState.overlayPath);
+  unlinkIfExists(ipcState.ipcPath);
+  unlinkIfExists(ipcState.overlayPath);
   ipcState = undefined;
+}
+
+function unlinkIfExists(filePath: string) {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function createIpcWriteCommand(ipcPath: string, payload: string): string {
+  if (process.platform === "win32") {
+    return [
+      "powershell",
+      "-NoProfile",
+      "-ExecutionPolicy Bypass",
+      "-Command",
+      `"Set-Content -LiteralPath ${quotePowerShell(ipcPath)} -Value ${quotePowerShell(payload)} -NoNewline"`,
+    ].join(" ");
+  }
+
+  return `printf '%s\\n' ${quotePosixShell(payload)} > ${quotePosixShell(
+    ipcPath
+  )}`;
+}
+
+function quotePosixShell(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function quotePowerShell(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function toYamlString(value: string): string {
+  return JSON.stringify(value);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,9 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
+		"types": [
+			"node"
+		],
 		"strict": true
 	},
 	"exclude": [


### PR DESCRIPTION
- Move LazyGit from an editor terminal to the VS Code terminal panel
- Add a status bar entry to open LazyGit
- Maximize the terminal panel and hide sidebars when LazyGit opens
- Add LazyGit-scoped shortcuts for Explorer, Search, Run and Debug, and Extensions
- Add LazyGit IPC fallback commands for Ctrl+E/F/D/X when terminal input drops Shift from Ctrl+Shift shortcuts
- Document the terminal limitations and local extension testing flow

https://github.com/tom-pollak/lazygit-vscode/issues/41