### PR TITLE
Restore layout when opening file with e

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ let lazyGitTerminal: vscode.Terminal | undefined;
 let globalConfig: LazyGitConfig;
 let globalConfigJSON: string;
 let ipcState: { ipcPath: string; overlayPath: string; watcher: fs.FSWatcher } | undefined;
+let ipcHandling: boolean;
 
 /* --- Config --- */
 
@@ -424,6 +425,9 @@ function startIpcWatcher(ipcPath: string): fs.FSWatcher {
 }
 
 function handleIpcMessage(line: string) {
+  if(ipcHandling) return;  // Guard to ensure we don't run the callback twice for the same file
+  ipcHandling = true;
+
   const parts = line.split("\t");
   const filePath = parts[0]?.trim();
   const lineNum = parts.length > 1 ? parseInt(parts[1], 10) : 0;
@@ -438,11 +442,13 @@ function handleIpcMessage(line: string) {
         preview: false,
         selection: new vscode.Range(position, position),
       });
+      onHide();
     },
     () => {
       vscode.window.showErrorMessage(`Failed to open file: ${filePath}`);
     }
   );
+  setTimeout(() => { ipcHandling = false; }, 1000);
 }
 
 function cleanupIpc() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -448,7 +448,7 @@ function handleIpcMessage(line: string) {
       vscode.window.showErrorMessage(`Failed to open file: ${filePath}`);
     }
   );
-  setTimeout(() => { ipcHandling = false; }, 1000);
+  setImmediate(() => { ipcHandling = false; });
 }
 
 function cleanupIpc() {


### PR DESCRIPTION
When opening a file with `e`, the file correctly opens, but the layout is not restored. The `hideRestore` option for the panels and the `autoMaximizeWindow` are not respected.

I suggest this change to call `onHide` when opening a file with IPC. The issue I faced when doing this on my system (Ubuntu 24.04), was that the `handleIPCMessage` was called twice. This lead to a double toggle of the panels (so nothing). I added a simple (maybe naive ?) guard to avoid calling `handleIPCMessage` twice in a second.

The change works on my setup.